### PR TITLE
LoRaMAC-flag

### DIFF
--- a/Examples/Applications/LoRaWAN-Base/Inc/main.h
+++ b/Examples/Applications/LoRaWAN-Base/Inc/main.h
@@ -29,7 +29,14 @@ extern "C" {
 #include "rf_driver_hal.h"
 #include "rf_driver_ll_rtc.h"
 #include "utils.h"
-#include "LoRaMac.h"
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+#include "rf_driver_hal_power_manager.h"
+#include "freertos_ble.h"
 
 
 /* Private includes ----------------------------------------------------------*/
@@ -56,6 +63,17 @@ extern "C" {
 /* Exported macro ------------------------------------------------------------*/
 
 /* Exported variables ---------------------------------------------------------*/
+extern SemaphoreHandle_t LoRaSemaphoreHandle;
+/* Binary semaphore used to synchronize Stack Tick and radio ISR. */
+extern SemaphoreHandle_t RadioIRQSemaphoreHandle;
+/* Mutex used to avoid that the BLE Stack Tick can be interrupted by an ACI
+   function in another thread. */
+extern SemaphoreHandle_t TestSemaphoreHandle;
+/* Mutex used to access UART resource */
+extern SemaphoreHandle_t UARTSemaphoreHandle;
+
+extern TaskHandle_t testHandle;
+extern TaskHandle_t loraHandle;
 
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);

--- a/Examples/Applications/LoRaWAN-Base/Inc/main.h
+++ b/Examples/Applications/LoRaWAN-Base/Inc/main.h
@@ -29,6 +29,7 @@ extern "C" {
 #include "rf_driver_hal.h"
 #include "rf_driver_ll_rtc.h"
 #include "utils.h"
+#include "LoRaMac.h"
 
 
 /* Private includes ----------------------------------------------------------*/
@@ -54,6 +55,7 @@ extern "C" {
 
 /* Exported macro ------------------------------------------------------------*/
 
+/* Exported variables ---------------------------------------------------------*/
 
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);

--- a/Examples/Applications/LoRaWAN-Base/Inc/main.h
+++ b/Examples/Applications/LoRaWAN-Base/Inc/main.h
@@ -30,14 +30,6 @@ extern "C" {
 #include "rf_driver_ll_rtc.h"
 #include "utils.h"
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "semphr.h"
-#include "rf_driver_hal_power_manager.h"
-#include "freertos_ble.h"
-
 
 /* Private includes ----------------------------------------------------------*/
 #include <stdio.h>
@@ -63,17 +55,6 @@ extern "C" {
 /* Exported macro ------------------------------------------------------------*/
 
 /* Exported variables ---------------------------------------------------------*/
-extern SemaphoreHandle_t LoRaSemaphoreHandle;
-/* Binary semaphore used to synchronize Stack Tick and radio ISR. */
-extern SemaphoreHandle_t RadioIRQSemaphoreHandle;
-/* Mutex used to avoid that the BLE Stack Tick can be interrupted by an ACI
-   function in another thread. */
-extern SemaphoreHandle_t TestSemaphoreHandle;
-/* Mutex used to access UART resource */
-extern SemaphoreHandle_t UARTSemaphoreHandle;
-
-extern TaskHandle_t testHandle;
-extern TaskHandle_t loraHandle;
 
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);

--- a/Examples/HTLRBL32L-SDK/LoRaWAN/lorawan_specifics/Mac/LoRaMac.c
+++ b/Examples/HTLRBL32L-SDK/LoRaWAN/lorawan_specifics/Mac/LoRaMac.c
@@ -354,6 +354,7 @@ typedef struct sLoRaMacCtx
  * Module context.
  */
 static LoRaMacCtx_t MacCtx;
+LoRaMacFlags_t* pMacCtxFlags = &(MacCtx.MacFlags);
 
 /*
  * Non-volatile module context.

--- a/Examples/HTLRBL32L-SDK/LoRaWAN/lorawan_specifics/Mac/LoRaMac.h
+++ b/Examples/HTLRBL32L-SDK/LoRaWAN/lorawan_specifics/Mac/LoRaMac.h
@@ -2646,6 +2646,8 @@ LoRaMacStatus_t LoRaMacMlmeRequest( MlmeReq_t* mlmeRequest );
  */
 LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t* mcpsRequest );
 
+extern LoRaMacFlags_t* pMacCtxFlags;
+
 /*!
  * Automatically add the Region.h file at the end of LoRaMac.h file.
  * This is required because Region.h uses definitions from LoRaMac.h


### PR DESCRIPTION
Added pointer pMacCtxFlags, which allows application level access to the MacFlags struct inside MacCtx (allowing better control of when TX/RX windows have ended).